### PR TITLE
fix: snupkg publish error (portable PDB + --no-symbols)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ defaults:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'skip-publish')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -104,7 +104,7 @@ jobs:
         NUGET_API_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
       run: |
         foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}/*.nupkg" | Where-Object { $_.Name -notlike "*.snupkg" })) {
-          dotnet nuget push $file --api-key "$env:NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          dotnet nuget push $file --api-key "$env:NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
         }
 
     - name: Create GitHub release

--- a/MageCorp.ClashRoyaleApi.Client/Converter/ClashRoyaleApiDateFormatJsonConverter.cs
+++ b/MageCorp.ClashRoyaleApi.Client/Converter/ClashRoyaleApiDateFormatJsonConverter.cs
@@ -17,7 +17,7 @@ internal class ClashRoyaleApiDateFormatJsonConverter : JsonConverter<DateTime?>
         if(reader.TokenType == JsonTokenType.Null)
             return null;
         
-        return DateTime.ParseExact(reader.GetString()!, "yyyyMMddTHHmmss.fffZ", CultureInfo.InvariantCulture);
+        return DateTime.ParseExact(reader.GetString() ?? string.Empty, "yyyyMMddTHHmmss.fffZ", CultureInfo.InvariantCulture);
     }
 
 

--- a/MageCorp.ClashRoyaleApi.Client/MageCorp.ClashRoyaleApi.Client.csproj
+++ b/MageCorp.ClashRoyaleApi.Client/MageCorp.ClashRoyaleApi.Client.csproj
@@ -23,6 +23,8 @@
     <AssemblyOriginatorKeyFile>ClashRoyaleApiClient.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <RepositoryUrl>https://github.com/rodrigopiccelli/MageCorp.ClashRoyaleApi.Client</RepositoryUrl>


### PR DESCRIPTION
The 3.0.0 release failed when pushing the .snupkg because the Release build did not generate portable PDB files.

**Changes:**
- Added \<DebugType>portable</DebugType>\ and \<DebugSymbols>true</DebugSymbols>\ to the library .csproj so future releases generate valid symbol packages.
- Added \--no-symbols\ to the \dotnet nuget push\ command to explicitly control symbol publishing and prevent the automatic .snupkg push from failing the workflow.